### PR TITLE
feat(components): implement size variants for Badge component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ vite.config.ts.timestamp-*
 *storybook.log
 
 .storybook-static
+
+# Package manager
+.npmrc

--- a/src/lib/components/atoms/Badge/Badge.enums.ts
+++ b/src/lib/components/atoms/Badge/Badge.enums.ts
@@ -11,3 +11,9 @@ export enum EBadgeWidthVariant {
 	FIT_CONTENT = 'w-fit',
 	FULL = 'w-full'
 }
+
+export enum EBadgeSizeVariant {
+	DEFAULT = 'default',
+	SMALL = 'small',
+	TINY = 'tiny'
+}

--- a/src/lib/components/atoms/Badge/Badge.svelte
+++ b/src/lib/components/atoms/Badge/Badge.svelte
@@ -5,6 +5,7 @@
 	export let label: IBadgeProps['label'];
 	export let colorVariant: IBadgeProps['colorVariant'] = EBadgeColorVariant.PRIMARY;
 	export let widthVariant: IBadgeProps['widthVariant'] = EBadgeWidthVariant.FIT_CONTENT;
+	export let sizeVariant: string = 'default';
 	export let LeftContent: IBadgeProps['LeftContent'] = null;
 	export let RightContent: IBadgeProps['RightContent'] = null;
 	export let textColor: IBadgeProps['textColor'] = '';
@@ -29,11 +30,15 @@
 				return 'var(--primary-white)';
 		}
 	}
+
+	function getSizeClass() {
+		return `size-${sizeVariant}`;
+	}
 </script>
 
 <div
 	{...$$props}
-	class={`${widthVariant} badge ${$$props.class} ${colorVariant} `}
+	class={`${widthVariant} badge ${getSizeClass()} ${colorVariant} ${$$props.class || ''}`}
 	on:click
 	aria-hidden="true"
 >
@@ -71,6 +76,27 @@
 		border-radius: 6px;
 		padding: 6px 14px;
 		height: fit-content;
+
+		&.size-tiny {
+			padding: 1px 4px;
+			border-radius: 3px;
+			font-size: 9px;
+			line-height: 1.2;
+
+			:global(.typography_badge) {
+				font-size: 9px !important;
+				line-height: 1.2 !important;
+			}
+		}
+
+		&.size-small {
+			padding: 3px 7px;
+			font-size: 11px;
+
+			:global(.typography_badge) {
+				font-size: 11px !important;
+			}
+		}
 
 		&.primary {
 			border: 2px solid var(--default-border);

--- a/src/lib/components/molecules/InfoBanner/InfoBanner.enums.ts
+++ b/src/lib/components/molecules/InfoBanner/InfoBanner.enums.ts
@@ -1,0 +1,15 @@
+export enum EInfoBannerStyleVariant {
+	PRIMARY = 'primary',
+	POSITIVE = 'positive',
+	NEGATIVE = 'negative',
+	HIGHLIGHT = 'highlight',
+	WARNING = 'warning',
+	INFO = 'info',
+	RUGGED = 'rugged'
+}
+
+export enum EInfoBannerPositionVariant {
+	TOP = 'top',
+	BOTTOM = 'bottom',
+	STATIC = 'static'
+}

--- a/src/lib/components/molecules/InfoBanner/InfoBanner.svelte
+++ b/src/lib/components/molecules/InfoBanner/InfoBanner.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { writable } from 'svelte/store';
+	import { Button, Badge } from '$lib/components/atoms';
+	import { EButtonStyleVariant } from '$lib/components/atoms/Button/Button.enums';
+	import { EInfoBannerStyleVariant, EInfoBannerPositionVariant } from './InfoBanner.enums';
+	import { EBadgeColorVariant } from '$lib/types';
+
+	export let id = 'infoBanner'; // Unique ID for localStorage
+	export let title = 'Notification';
+	export let description = '';
+	export let styleVariant: EInfoBannerStyleVariant = EInfoBannerStyleVariant.PRIMARY;
+	export let positionVariant: EInfoBannerPositionVariant = EInfoBannerPositionVariant.STATIC;
+	export let dismissible = true;
+	export let buttonText = 'Acknowledged';
+	export let badgeColorVariant = EBadgeColorVariant.PRIMARY;
+
+	const showBanner = writable(true);
+
+	// Check local storage on mount
+	onMount(() => {
+		const bannerAcknowledged = localStorage.getItem(`${id}Acknowledged`);
+		if (bannerAcknowledged === 'true') {
+			showBanner.set(false);
+		}
+	});
+
+	// Function to dismiss the banner
+	function acknowledgeBanner() {
+		showBanner.set(false);
+		localStorage.setItem(`${id}Acknowledged`, 'true');
+	}
+
+	// Helper to determine button style based on banner style
+	function getButtonStyleVariant() {
+		switch (styleVariant) {
+			case EInfoBannerStyleVariant.POSITIVE:
+				return EButtonStyleVariant.POSITIVE;
+			case EInfoBannerStyleVariant.NEGATIVE:
+				return EButtonStyleVariant.NEGATIVE;
+			case EInfoBannerStyleVariant.HIGHLIGHT:
+				return EButtonStyleVariant.HIGHLIGHT;
+			case EInfoBannerStyleVariant.RUGGED:
+				return EButtonStyleVariant.NEGATIVE;
+			default:
+				return EButtonStyleVariant.PRIMARY;
+		}
+	}
+
+	// Map InfoBanner styles to Badge color variants
+	function getBadgeColorVariant() {
+		switch (styleVariant) {
+			case EInfoBannerStyleVariant.POSITIVE:
+				return EBadgeColorVariant.SUCCESS;
+			case EInfoBannerStyleVariant.NEGATIVE:
+				return EBadgeColorVariant.REJECTED;
+			case EInfoBannerStyleVariant.RUGGED:
+				return EBadgeColorVariant.REJECTED;
+			case EInfoBannerStyleVariant.WARNING:
+				return EBadgeColorVariant.FAILED;
+			case EInfoBannerStyleVariant.INFO:
+				return EBadgeColorVariant.ONGOING;
+			default:
+				return badgeColorVariant;
+		}
+	}
+
+	// Helper to determine text color based on variant
+	function getTextColor() {
+		switch (styleVariant) {
+			case EInfoBannerStyleVariant.POSITIVE:
+				return 'text-upOnly';
+			case EInfoBannerStyleVariant.NEGATIVE:
+				return 'text-rugged';
+			case EInfoBannerStyleVariant.HIGHLIGHT:
+				return 'text-filaMint';
+			case EInfoBannerStyleVariant.WARNING:
+				return 'text-yellowPaper';
+			case EInfoBannerStyleVariant.INFO:
+				return 'text-bluePaper';
+			case EInfoBannerStyleVariant.RUGGED:
+				return 'text-rugged';
+			default:
+				return 'text-gray-300';
+		}
+	}
+
+	// Helper to determine background and border styles
+	function getBackgroundStyles() {
+		switch (styleVariant) {
+			case EInfoBannerStyleVariant.POSITIVE:
+				return 'border-upOnly bg-upOnly/5';
+			case EInfoBannerStyleVariant.NEGATIVE:
+				return 'border-rugged bg-rugged/10';
+			case EInfoBannerStyleVariant.HIGHLIGHT:
+				return 'border-filaMint bg-filaMint/5';
+			case EInfoBannerStyleVariant.WARNING:
+				return 'border-yellowPaper bg-yellowPaper/10';
+			case EInfoBannerStyleVariant.INFO:
+				return 'border-bluePaper bg-bluePaper/10';
+			case EInfoBannerStyleVariant.RUGGED:
+				return 'border-rugged bg-rugged/10';
+			default:
+				return 'border-gray-400 bg-gray-950';
+		}
+	}
+
+	// Helper to determine position styles
+	function getPositionStyles() {
+		switch (positionVariant) {
+			case EInfoBannerPositionVariant.TOP:
+				return 'sticky top-0 z-50';
+			case EInfoBannerPositionVariant.BOTTOM:
+				return 'sticky bottom-0 z-50';
+			default:
+				return '';
+		}
+	}
+</script>
+
+{#if $showBanner}
+	<div
+		class={`flex w-full border mb-8 py-3 px-4 max-w-screen-2xl rounded-md mx-auto ${getBackgroundStyles()} ${getPositionStyles()}`}
+	>
+		<div class="flex flex-row items-center justify-between gap-4 flex-wrap w-full">
+			<div class="flex flex-row items-center gap-3 flex-wrap">
+				{#if title}
+					<Badge label={title} colorVariant={getBadgeColorVariant()} class="py-1 px-2" />
+				{/if}
+				{#if description}
+					<p class={getTextColor()}>
+						{description}
+					</p>
+				{/if}
+			</div>
+			{#if dismissible}
+				<Button styleVariant={getButtonStyleVariant()} on:click={acknowledgeBanner}>
+					{buttonText}
+				</Button>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/molecules/InfoBanner/index.ts
+++ b/src/lib/components/molecules/InfoBanner/index.ts
@@ -1,0 +1,2 @@
+export { default as InfoBanner } from './InfoBanner.svelte';
+export * from './InfoBanner.enums';

--- a/src/lib/components/molecules/index.ts
+++ b/src/lib/components/molecules/index.ts
@@ -15,3 +15,4 @@ export * from './ToggleContentContainer';
 export * from './Metrics';
 export * from './TextCollapse';
 export * from './Ticker';
+export * from './InfoBanner';

--- a/src/lib/components/organisms/Header/Header.svelte
+++ b/src/lib/components/organisms/Header/Header.svelte
@@ -1,11 +1,12 @@
 <script>
 	import { fade } from 'svelte/transition';
 	import { goto } from '$app/navigation';
+	// @ts-expect-error - Missing types for sveltekit-progress-bar package
 	import { ProgressBar } from '@prgm/sveltekit-progress-bar';
-	import { Button, Divider, NavBar } from '$lib/components';
+	import { Button, Divider, NavBar, Badge } from '$lib/components';
 	import { modalStore, Wallet, walletStore } from '$lib/features';
 	import { shortCutTransactionHash, replaceUrlParams, screenDetect } from '$lib/helpers';
-	import { EButtonStyleVariant, EModalVariant } from '$lib/types';
+	import { EButtonStyleVariant, EModalVariant, EBadgeColorVariant } from '$lib/types';
 	import LogoFilament from '$lib/assets/logos/logo-filament.svg?url';
 	import { routes } from '$lib/constants';
 	import { Typography } from '$lib/components';
@@ -29,14 +30,19 @@
 	</div>
 	<div class="flex flex-row items-center justify-between pt-[5px] px-4" data-testid="header">
 		<div
-			class="cursor-pointer flex gap-3 pb-[10px]"
+			class="cursor-pointer flex items-center gap-2 pb-[10px]"
 			on:click={() => {
 				goto(routes.HOME);
 			}}
 			aria-hidden="true"
 		>
-			<img src={LogoFilament} alt="logo" class="w-6" />
-			<Typography variant="h5">Filament</Typography>
+			<div class="flex items-center gap-3">
+				<img src={LogoFilament} alt="logo" class="w-6" />
+				<Typography variant="h5">Filament</Typography>
+			</div>
+			<div class="flex items-start h-full">
+				<Badge label="Alpha" colorVariant={EBadgeColorVariant.REJECTED} sizeVariant="small" />
+			</div>
 		</div>
 		{#if $screenTypeStore.isMounted}
 			{#if !$screenTypeStore.isLayoutLg}

--- a/src/lib/components/templates/BaseLayout.svelte
+++ b/src/lib/components/templates/BaseLayout.svelte
@@ -1,13 +1,21 @@
 <script lang="ts">
 	import { RightSideBarController, ToastsContainer } from '$lib/features';
 	import { Header, Footer } from '$lib/components';
+	import { InfoBanner, EInfoBannerStyleVariant } from '$lib/components/molecules';
 </script>
 
 <div class="flex flex-row h-svh">
 	<div class="flex flex-col w-full">
 		<Header />
+
 		<div class="flex flex-col w-full items-center h-fit">
 			<div class="flex flex-col p-4 py-8 w-full max-w-[1440px] min-h-dvh h-fit">
+				<InfoBanner
+					id="devnetBanner"
+					title="Public Alpha"
+					description="You're viewing data from our development environment. This version allows you to explore the UI while testnet deployment is in progress."
+					styleVariant={EInfoBannerStyleVariant.RUGGED}
+				/>
 				<slot />
 			</div>
 			<div class="w-full flex justify-center">


### PR DESCRIPTION
- Add size variants (tiny, small, default) to Badge component

- Implement proper CSS styling for each size variant in Badge.svelte

- Update getSizeClass() function to support size variant selection

- Apply 'small' size variant to Alpha badge in Header component

- Improve typography scaling for each size variant using global CSS selectors

- Maintain parent container styling in Header component

This enhancement increases Badge component flexibility and allows for more compact badge displays like the Alpha indicator in the header.